### PR TITLE
Remove redundant let ... in

### DIFF
--- a/Import.elm
+++ b/Import.elm
@@ -15,12 +15,9 @@ parse source =
 
 
 imports : List RawImport -> Dict.Dict String Import
-imports rawImports =
-  let toDict list =
-        Dict.union (Dict.fromList (List.map toImport list)) defaultImports
-  in
-      toDict rawImports
-
+imports rawImportList =
+  Dict.union (Dict.fromList (List.map toImport rawImportList)) defaultImports
+  
 
 (=>) name exposed =
   (name, Import Nothing exposed)


### PR DESCRIPTION
`toDict`'s only function is to bind `list` to `rawImports`; I think the method is clearer with the `List RawImport` parameter renamed `rawImportList`
